### PR TITLE
Reownsdk: worked on the findProvider method and casting the provider as ISolana

### DIFF
--- a/packages/@dynamic-labs-connectors/walletconnect-solana/src/ReownSdkClient.spec.ts
+++ b/packages/@dynamic-labs-connectors/walletconnect-solana/src/ReownSdkClient.spec.ts
@@ -59,19 +59,19 @@ describe('ReownSdkClient', () => {
 
   describe('getProvider', () => {
     it('should return return true for all these proving it is casted to ISolana as Dynamic WalletConnect', async () => {
-      // const fakeAdapter = { 
-      //   connect: jest.fn(),
-      //   publicKey: { 
-      //     toString: () => 'FakePublicKey', 
-      //   },
-      //   signMessage: jest.fn(),
-      // } as unknown as WalletConnectWalletAdapter;
+      const fakeAdapter = { 
+        connect: jest.fn(),
+        publicKey: { 
+          toString: () => 'FakePublicKey', 
+        },
+        signMessage: jest.fn(),
+      } as unknown as WalletConnectWalletAdapter;
 
       await ReownSdkClient.init();
-      // expect(ReownSdkClient.getProvider()).toStrictEqual(fakeAdapter);   
-      expect(typeof ReownSdkClient.getProvider().connect).toBe('function');
-      expect(typeof ReownSdkClient.getProvider().signMessage).toBe('function');
-      expect(ReownSdkClient.getProvider().publicKey).toHaveProperty('toString');
+      expect(ReownSdkClient.getProvider()).toStrictEqual(fakeAdapter);   
+      // expect(typeof ReownSdkClient.getProvider().signTransaction).toBe('function');
+      // expect(typeof ReownSdkClient.getProvider().signMessage).toBe('function');
+      // expect(ReownSdkClient.getProvider().publicKey).toHaveProperty('toString');
     });
   });
 

--- a/packages/@dynamic-labs-connectors/walletconnect-solana/src/ReownSdkClient.ts
+++ b/packages/@dynamic-labs-connectors/walletconnect-solana/src/ReownSdkClient.ts
@@ -10,7 +10,7 @@ export class ReownSdkClient {
   static isInitialized = false;
   static adapter: SolanaAdapter;
   static walletConnectSdk: WalletConnectWalletAdapter;
-
+  static isConnected = false;
 
   // Private constructor: this class is a singleton.
   private constructor() {
@@ -22,8 +22,6 @@ export class ReownSdkClient {
     if (ReownSdkClient.isInitialized) {
       return;
     }
-
-    ReownSdkClient.isInitialized = true;
     
     logger.debug('[ReownSdkClient] Initializing Solana adapter');
 
@@ -41,7 +39,6 @@ export class ReownSdkClient {
     ReownSdkClient.walletConnectSdk  = new WalletConnectWalletAdapter(walletConnectConfig);
 
     await ReownSdkClient.connect();
-
     ReownSdkClient.isInitialized = true;
   }
 
@@ -52,9 +49,9 @@ export class ReownSdkClient {
 
     // Returns the provider from the adapter. Adjust as needed if your adapter exposes a different property.
     static getProvider = () => {
-        // Casting to IEthereum because the Safe provider implements the eip-1193 interface
-        // And that the expected type for the parent class EthereumInjectedConnector
-        return ReownSdkClient.adapter as unknown as ISolana;
+        // Casting to ISolana because the walletConnect provider implements the solana interface
+        // And that the expected type for the parent class SolanaInjectedContainer
+        return ReownSdkClient.walletConnectSdk as unknown as ISolana;
     };
 
 
@@ -77,5 +74,7 @@ export class ReownSdkClient {
             if (!publicKey) {
         throw new Error("Failed to connect wallet: publicKey is undefined");
         }
+
+        ReownSdkClient.isConnected = ReownSdkClient.walletConnectSdk.connected;
     }
 }

--- a/packages/@dynamic-labs-connectors/walletconnect-solana/src/ReownSdkClient.ts
+++ b/packages/@dynamic-labs-connectors/walletconnect-solana/src/ReownSdkClient.ts
@@ -1,9 +1,18 @@
 // ReownSdkClient.ts
-import { SolanaAdapter } from '@reown/appkit-adapter-solana';
+import { SolanaAdapter, type AdapterOptions } from '@reown/appkit-adapter-solana';
 import { logger } from '@dynamic-labs/wallet-connector-core';
 import { WalletConnectWalletAdapter, type WalletConnectWalletAdapterConfig } from '@solana/wallet-adapter-walletconnect';
 import type { ISolana } from '@dynamic-labs/solana-core';
 import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
+import {
+  Transaction,
+  VersionedTransaction,
+  SendOptions,
+  TransactionSignature,
+  PublicKey,
+  Connection
+} from '@solana/web3.js';
+
 
 export class ReownSdkClient {
 
@@ -34,11 +43,10 @@ export class ReownSdkClient {
       },
     // Use a literal string that matches one of the allowed values.
     };
-
     // Instantiate your Solana adapter.
     ReownSdkClient.walletConnectSdk  = new WalletConnectWalletAdapter(walletConnectConfig);
 
-    await ReownSdkClient.connect();
+
     ReownSdkClient.isInitialized = true;
   }
 
@@ -48,10 +56,70 @@ export class ReownSdkClient {
     }
 
     // Returns the provider from the adapter. Adjust as needed if your adapter exposes a different property.
-    static getProvider = () => {
-        // Casting to ISolana because the walletConnect provider implements the solana interface
-        // And that the expected type for the parent class SolanaInjectedContainer
-        return ReownSdkClient.walletConnectSdk as unknown as ISolana;
+    // static getProvider = (): ISolana => {
+    //     // Casting to ISolana because the walletConnect provider implements the solana interface
+    //     // And that the expected type for the parent class SolanaInterface
+    //     return ReownSdkClient.walletConnectSdk as unknown as ISolana;
+    // };
+    static getProvider = (): ISolana => {
+      const adapter = ReownSdkClient.walletConnectSdk;
+      if (!adapter) {
+        throw new Error("WalletConnect adapter is not initialized");
+      }
+      // Return a new object that conforms to the ISolana interface.
+      // const provider: ISolana = {       
+      //   // Expose the underlying publicKey.
+      //   publicKey: adapter.publicKey || undefined,
+      //   isConnected: ReownSdkClient.isConnected,
+  
+      //   // Connect: delegate to adapter.connect and then return the publicKey as string.
+      //   connect: async () => {
+      //     await adapter.connect();
+      //     if (!adapter.publicKey) {
+      //       throw new Error("Wallet not connected");
+      //     }
+      //     return { publicKey: adapter.publicKey.toString() }; // returns an object matching ConnectionResult
+      //   },
+  
+      //   // Disconnect: delegate to adapter.disconnect.
+      //   disconnect: () => adapter.disconnect(),
+  
+      //   // signMessage: delegate to adapter.signMessage.
+      //   signMessage: async (message: Uint8Array, encoding?: string) => {
+      //     const result = await adapter.signMessage(message);
+      //     return { signature: result };
+      //   },
+          
+      //   // signTransaction: if supported by the adapter, delegate to it.
+      //   signTransaction: async <T extends Transaction | VersionedTransaction>(tx: T): Promise<T> => {
+      //     if (adapter.signTransaction) {
+      //       return await adapter.signTransaction(tx);
+      //     }
+      //     throw new Error("signTransaction is not supported by the adapter");
+      //   },
+  
+      //   // signAllTransactions: delegate if available.
+      //   signAllTransactions: async <T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]> => {
+      //     if (adapter.signAllTransactions) {
+      //       return await adapter.signAllTransactions(txs);
+      //     }
+      //     throw new Error("signAllTransactions is not supported by the adapter");
+      //   },
+  
+      //   // signAndSendTransaction: delegate if available.
+      //   // signAndSendTransaction: async <T extends Transaction | VersionedTransaction>(
+      //   //   tx: T,
+      //   //   options?: SendOptions
+      //   // ): Promise<{ signature: TransactionSignature }> => {
+      //   //   if (adapter.signAndSendTransaction) {
+      //   //     return await adapter.signAndSendTransaction(tx, options);
+      //   //   }
+      //   //   throw new Error("signAndSendTransaction is not supported by the adapter");
+      //   // },
+  
+      // };
+  
+      return SolanaAdapter as unknown as ISolana;
     };
 
 

--- a/packages/@dynamic-labs-connectors/walletconnect-solana/src/WalletConnectSolanaConnector.spec.ts
+++ b/packages/@dynamic-labs-connectors/walletconnect-solana/src/WalletConnectSolanaConnector.spec.ts
@@ -79,7 +79,9 @@ describe('WalletConnectSolanaConnector', () => {
   describe('connect', () => {
     it('should call ReownSdkClient.connect', async () => {
       await connector.connect();
+      // const provider = ReownSdkClient.getProvider();
       expect(ReownSdkClient.connect).toHaveBeenCalled();
+      // expect(provider.isConnected).toBe(true);
     });
   });
 
@@ -113,4 +115,20 @@ describe('WalletConnectSolanaConnector', () => {
       expect(signature).toEqual(new Uint8Array([1, 2, 3]).toString());
     });
   });
+
+  // describe('getProvider compatibility', () => {
+  //   it('should return a provider compatible with ISolana', async () => {
+  //     // Retrieve the provider (this should already satisfy the ISolana interface).
+  //     const provider = ReownSdkClient.getProvider();
+  //     // Check that the provider has the expected methods and properties.
+  //     expect(typeof provider.connect).toBe('function');
+  //     expect(typeof provider.signMessage).toBe('function');
+  //     // You can add more checks for other required methods or properties.
+  
+  //     // Similarly, if signMessage is supposed to return a specific signature:
+  //     const signature = await provider.signMessage(new Uint8Array([10, 20, 30]));
+  //     expect(signature).toEqual(new Uint8Array([10, 20, 30])); // Adjust the expected output as needed.
+  //   });
+  // });
+  
 });


### PR DESCRIPTION
- ReownProvider.ts is a class used to cast the provider as an ISolana Object. 
- ReownSdkClient.ts is used to initialize WalletConnect along with the Provider
- WalletConnectSolana.ts is used to connect the other two components to Dynamic Labs.
- Open to naming suggestions for ReownSdkClient and ReownProvider. 